### PR TITLE
Fix Rate component erasing data

### DIFF
--- a/src/components/Input/Rate/Rate/Rate.tsx
+++ b/src/components/Input/Rate/Rate/Rate.tsx
@@ -50,6 +50,8 @@ const Rate: React.FC<RateProps> = ({
     { rating: 4, isActive: false },
     { rating: 5, isActive: false },
   ]);
+  const [selectedRating, setSelectedRating] = useState<Number>(rating)
+
   const handleRateChange = useCallback((rating: number) => {
     setCurrentRating(
       currentRating.map((item, index) => {
@@ -60,6 +62,7 @@ const Rate: React.FC<RateProps> = ({
         }
       })
     );
+    setSelectedRating(rating)
 
     if (onRateChange) {
       onRateChange(rating);
@@ -88,6 +91,7 @@ const Rate: React.FC<RateProps> = ({
           {currentRating.map((item, index) => {
             return (
               <StyledRateIcon
+                data-testid={`rating-icon-${item.rating}`}
                 key={index}
                 color={item.isActive ? color : "#ccc"}
                 style={{
@@ -98,9 +102,9 @@ const Rate: React.FC<RateProps> = ({
                   !disabled?handleRateChange(item.rating): null;
                   if(allowClear) {
                     //IF IT IS THE SAME ITEM CLICKED, CLEAR ALL
-                    if (item.isActive && clicked) {
+                    if (item.isActive && clicked && item.rating === selectedRating) {
                       clearAll();
-                    } 
+                    }
                     setClicked(true);
                   }
                 }}

--- a/src/components/Input/Rate/tests/rate.test.tsx
+++ b/src/components/Input/Rate/tests/rate.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { Rate } from "..";
 
 describe("Rate component", () => {
@@ -8,4 +8,54 @@ describe("Rate component", () => {
         expect(screen.getByRole("rate")).toBeInTheDocument();
     });
 
+    it("should clear rating if same rating is clicked twice", () => {
+        const RATING = 3
+        const GOLD_COLOR = "#ffc107"
+        const GREY_COLOR = "#ccc"
+
+        render(<Rate rating={RATING} color={GOLD_COLOR}/>);
+
+        const threeStarIcon = screen.getByTestId(`rating-icon-${RATING}`)
+        const starIcons = [
+            screen.getByTestId("rating-icon-1"),
+            screen.getByTestId("rating-icon-2"),
+            threeStarIcon
+        ]
+
+        starIcons.forEach(icon => expect(icon.attributes.color.value).toEqual(GOLD_COLOR))
+
+        fireEvent(threeStarIcon, new MouseEvent("click", {bubbles: true}))
+
+        starIcons.forEach(icon => expect(icon.attributes.color.value).toEqual(GREY_COLOR))
+    })
+
+    it('should not clear all ratings when rating is changed from higher to lower', () => {
+        const RATING = 5
+        const GOLD_COLOR = "#ffc107"
+        const GREY_COLOR = "#ccc"
+
+        render(<Rate rating={RATING} color={GOLD_COLOR}/>);
+
+        const threeStarIcon = screen.getByTestId('rating-icon-3')
+        const firstThreeStarIcons = [
+            screen.getByTestId("rating-icon-1"),
+            screen.getByTestId("rating-icon-2"),
+            threeStarIcon
+        ];
+
+        const lastTwoStarIcons = [
+            screen.getByTestId("rating-icon-4"),
+            screen.getByTestId("rating-icon-5"),
+        ];
+
+        [...firstThreeStarIcons, ...lastTwoStarIcons]
+            .forEach(
+                icon => expect(icon.attributes.color.value).toEqual(GOLD_COLOR)
+            )
+
+        fireEvent(threeStarIcon, new MouseEvent("click", {bubbles: true}))
+
+        firstThreeStarIcons.forEach(icon => expect(icon.attributes.color.value).toEqual(GOLD_COLOR))
+        lastTwoStarIcons.forEach(icon => expect(icon.attributes.color.value).toEqual(GREY_COLOR))
+    })
 });


### PR DESCRIPTION
Fixes https://github.com/ahmedwab/Twizzle/issues/33

## Description
 This PR fixes an issue where the `Rate` component would erase the current rating when changing the rating from a higher to lower value. Instead, the desired behaviour is to set the rating to the newly clicked numeric rating. 

I added a `selectedRating` piece of state to track the numeric rating. Inside the `StyledRateIcon.onClick` logic, I changed it to only invoke the `clearAll` method if previous conditions were met, and the user is clicking on the same numeric rating that is already set. Otherwise, the normal flow happens and the rating is updated to `item.rating`. 

Example:
- Previously, clicking on 5 stars &rarr; 3 stars would completely erase the rating

- New behaviour:
   - Clicking on 5 stars &rarr; 3 stars changes the rating from 5 star to 3 star, removing 2 stars. 
   - Clicking on the same rating 5 stars &rarr; 5 stars removes the rating

## Notes
I was unable to run tests from inside my IDE, but tests ran fine from the command line. Let me know if there any changes you'd like to make to either the implementation or the tests!